### PR TITLE
NOOS-517/cross-platform-docker-images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.13] - 2023-09-18
 ### Changed
  - Bump Poetry version to v1.5.1.
+
+## [0.0.14] - 2023-11-17
+### Added
+ - Add docker.buildx to build and push multi-platform images.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool.poetry]
 # Description
 name = "noos-inv"
-version = "0.0.13"
+version = "0.0.14"
 description = "Shared workflows across CI/CD pipelines"
 # Credentials
 license = "MIT"

--- a/src/tests/test_docker.py
+++ b/src/tests/test_docker.py
@@ -122,3 +122,25 @@ class TestDockerPush:
 
         assert test_run.call_count == 1
         test_run.assert_called_with(cmd)
+
+
+class TestDockerBuildx:
+    @pytest.mark.parametrize("image_platfom", ["linux/arm64", "linux/arm64,linux/amd64"])
+    def test_fetch_command_correctly_with_platform(
+        self, test_run, ctx, image_context, image_file, image_platfom
+    ):
+        cmd = (
+            f"docker buildx build --pull --file {image_file} --tag test-repo/test-image:latest "
+            f"--platform {image_platfom} --push {image_context}"
+        )
+
+        docker.buildx(
+            ctx,
+            repo="test-repo",
+            name="test-image",
+            file=image_file,
+            context=image_context,
+            platform=image_platfom,
+        )
+
+        test_run.assert_called_with(cmd)


### PR DESCRIPTION
`docker.buildx` will build and push the image in the repo
Using `buildx` without `--push`, I get the error `WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load`
And I can't using `--load` with multiple platforms