### PR TITLE
NOOS-1193/circleci-multi-arch-docker-builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add docker.pull as a convience and symmetry command to docker.push.
 ### Changed
  - Refactor entire repositories into modular composable components.
+
+## [0.2.4] - 2025-03-05
+### Changed
+ - docker.configure now registers QEMU for multi-platform builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool.poetry]
 # Description
 name = "noos-inv"
-version = "0.2.3"
+version = "0.2.4"
 description = "Shared workflows across CI/CD pipelines"
 # Credentials
 license = "MIT"

--- a/src/noos_inv/tasks/docker.py
+++ b/src/noos_inv/tasks/docker.py
@@ -58,6 +58,9 @@ def _dockerhub_login(ctx: Context, user: str, token: str | None) -> None:
 @task()
 def configure(ctx: Context, builder: str = "multi-platform-builder") -> None:
     """Create and provision buildx builder for multi-platform."""
+    # Register QEMU with the kernel so that Docker can emulate other architectures.
+    ctx.run("docker run --rm --privileged multiarch/qemu-user-static --reset -p yes")
+    # Create and use the buildx builder
     ctx.run(f"docker buildx create --name {builder} --use")
     ctx.run("docker buildx inspect --bootstrap")
 


### PR DESCRIPTION
# Description
`$ noosinv docker.configure` now registers QEMU* with the kernel, before initialising the `buildx` builder, so that Docker can emulate and successfully build for other architectures, namely `linux/arm64`.

\*  QEMU is an open-source emulator and virtualizer that allows one system to run software compiled for a different hardware architecture by dynamically translating instructions.

<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-1193](https://noosenergy.atlassian.net/browse/NOOS-1193)

[NOOS-1193]: https://noosenergy.atlassian.net/browse/NOOS-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ