### PR TITLE
hotfix/change-default-python-installer-to-uv

### DIFF
--- a/src/noos_inv/tasks/python.py
+++ b/src/noos_inv/tasks/python.py
@@ -5,7 +5,7 @@ from noos_inv import exceptions, types, validators
 
 CONFIG = {
     "python": {
-        "install": "pipenv",
+        "install": "uv",
         "source": "./src",
         "formatters": "ruff",
         "linters": "ruff,mypy",


### PR DESCRIPTION
Use `uv` as default python installer instead of `pipenv`