### PR TITLE
feature/python-test-num-workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool.poetry]
 # Description
 name = "noos-inv"
-version = "0.2.5"
+version = "0.2.6"
 description = "Shared workflows across CI/CD pipelines"
 # Credentials
 license = "MIT"

--- a/src/noos_inv/tasks/python.py
+++ b/src/noos_inv/tasks/python.py
@@ -12,6 +12,7 @@ CONFIG = {
         "tests": "./src/tests",
         "user": None,
         "token": None,
+        "numprocesses": 8,
     }
 }
 
@@ -85,17 +86,19 @@ def test(
         tests: str | None = None,
         group: str = "",
         install: str | None = None,
-        num_workers: int = 8,
+        numprocesses: int = 0,
 ) -> None:
     """Run pytest with optional grouped tests."""
     tests = tests or ctx.python.tests
+    numprocesses = numprocesses or ctx.python.numprocesses
     if group != "":
         tests += "/" + types.GroupType.get(group)
     validators.check_path(tests)
     cmd = _activate_shell(ctx, install)
     pytest_cmd = "pytest"
-    if num_workers > 1:
-        pytest_cmd += f" --numprocesses={num_workers} {tests}"
+    if numprocesses > 1:
+        pytest_cmd += f" --numprocesses={numprocesses}"
+    pytest_cmd += f" {tests}"
     ctx.run(cmd + pytest_cmd, pty=True)
 
 

--- a/src/noos_inv/tasks/python.py
+++ b/src/noos_inv/tasks/python.py
@@ -81,7 +81,11 @@ def lint(
 
 @task()
 def test(
-    ctx: Context, tests: str | None = None, group: str = "", install: str | None = None
+        ctx: Context,
+        tests: str | None = None,
+        group: str = "",
+        install: str | None = None,
+        num_workers: int = 8,
 ) -> None:
     """Run pytest with optional grouped tests."""
     tests = tests or ctx.python.tests
@@ -89,7 +93,8 @@ def test(
         tests += "/" + types.GroupType.get(group)
     validators.check_path(tests)
     cmd = _activate_shell(ctx, install)
-    ctx.run(cmd + f"pytest {tests}", pty=True)
+    pytest_cmd = f"pytest --numprocesses={num_workers}"
+    ctx.run(cmd + pytest_cmd, pty=True)
 
 
 @task()

--- a/src/noos_inv/tasks/python.py
+++ b/src/noos_inv/tasks/python.py
@@ -95,7 +95,7 @@ def test(
     cmd = _activate_shell(ctx, install)
     pytest_cmd = "pytest"
     if num_workers > 1:
-        pytest_cmd += f" --numprocesses={num_workers}"
+        pytest_cmd += f" --numprocesses={num_workers} {tests}"
     ctx.run(cmd + pytest_cmd, pty=True)
 
 

--- a/src/noos_inv/tasks/python.py
+++ b/src/noos_inv/tasks/python.py
@@ -93,7 +93,9 @@ def test(
         tests += "/" + types.GroupType.get(group)
     validators.check_path(tests)
     cmd = _activate_shell(ctx, install)
-    pytest_cmd = f"pytest --numprocesses={num_workers}"
+    pytest_cmd = "pytest"
+    if num_workers > 1:
+        pytest_cmd += f" --numprocesses={num_workers}"
     ctx.run(cmd + pytest_cmd, pty=True)
 
 

--- a/src/tests/tasks/test_python.py
+++ b/src/tests/tasks/test_python.py
@@ -66,7 +66,7 @@ class TestPythonTest:
     @pytest.mark.parametrize("group", ["unit", "integration", "functional"])
     def test_fetch_command_correctly(self, tmp_path, test_run, ctx, group):
         (tmp_path / group).mkdir()
-        cmd = f"pipenv run pytest {tmp_path / group}"
+        cmd = f"pipenv run pytest --numprocesses=8 {tmp_path / group}"
 
         python.test(ctx, tests=tmp_path.as_posix(), group=group, install="pipenv")
 


### PR DESCRIPTION
Currently this is set in individual project's pyproject.toml, but this can be annoying as this apply to tests run through VSC as well and the parallelism messes up with the debugger and takes longer to setup than just running a small subset of the tests with a single worker.