### PR TITLE
hotfix/argo-syntax-change

### DIFF
--- a/src/noos_inv/tasks/local.py
+++ b/src/noos_inv/tasks/local.py
@@ -41,7 +41,7 @@ def argo_submit(
     else:
         if not command:
             raise exceptions.UndefinedVariable("Missing valid -c, --command parameter")
-        call_cmd = f'--from wftmplt/{template} -p "command={command}"'
+        call_cmd = f'--from workflowtemplate/{template} -p "command={command}"'
     base_cmd = f"ARGO_SECURE=false argo -s localhost:2746 submit -n {namespace}"
     cmd = f"{base_cmd} {call_cmd}"
     try:


### PR DESCRIPTION
# Description
Update Argo workflow template path prefix

```
Error: failed to submit workflow: rpc error: code = InvalidArgument desc = Resource kind 'wftmplt' is not supported for submitting
```
<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-<num>](https://noosenergy.atlassian.net/browse/NOOS-<num>)

## Deployment

Once merged, check deployment on [circleci](https://app.circleci.com/pipelines/github/noosenergy/noos-invoke)
